### PR TITLE
Add very basic test that module can be used

### DIFF
--- a/t/00-use-module.t
+++ b/t/00-use-module.t
@@ -1,0 +1,9 @@
+use v6;
+
+use Test;
+
+plan 1;
+
+use-ok 'Perl6::Format';
+
+# vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
At the least a module should be able to be used without error, and this is
what this change does.  This test helped highlight a dependency of the
module and showed up a deprecated code issue (which will be corrected in a
following commit).
