### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Perl6/Format.pm
+++ b/lib/Perl6/Format.pm
@@ -1,5 +1,5 @@
 use Perl6::Parsing;
-class Perl6::Format;
+unit class Perl6::Format;
 
 
 constant $debug = 0;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.
